### PR TITLE
Update for latest API changes in emacs-citar/citar#661

### DIFF
--- a/citar-org-roam.el
+++ b/citar-org-roam.el
@@ -153,16 +153,17 @@ This is just a wrapper for 'org-roam-ref-add'."
 Each candidate is a 'citekey' + 'node-id' string, separated by a
 space."
   ;; REVIEW experimental
-  (let ((refs (if keys
-                  (mapcan #'citar-org-roam--get-ref-nodes-for-key keys)
-                (citar-org-roam--get-ref-nodes))))
-    (mapcar
-     (lambda (ref)
-       (let* ((citekey (car ref))
-              (nodeid (cadr ref)))
-         (concat
-          citekey " " (propertize nodeid 'invisible t))))
-     refs)))
+  (let ((nodes (org-roam-db-query `[:select [refs:node-id refs:ref nodes:title]
+                                            :from [refs nodes]
+                                            :where (and (= refs:type "cite")
+                                                        (= refs:node-id nodes:id)
+                                                        ,@(when keys '((in refs:ref $v1))))]
+                                  (vconcat keys)))
+        (cands (make-hash-table :test 'equal)))
+    (prog1 cands
+      (pcase-dolist (`(,nodeid ,citekey ,_title) nodes)
+        ;; TODO include note title in the candidate string?
+        (push (concat citekey " " (propertize nodeid 'invisible t)) (gethash citekey cands))))))
 
 (defun citar-org-roam-select-ref ()
   "Return org-roam node-id for ref candidate."


### PR DESCRIPTION
Return note candidates as a hash table rather than as a list, following the API update in emacs-citar/citar#661.

Also use a single SQL query to get all ref nodes and associated information.