### PR TITLE
Add citekey with `org-roam-ref-add'

### DIFF
--- a/citar-org-roam.el
+++ b/citar-org-roam.el
@@ -184,15 +184,13 @@ space."
           ;; REVIEW not sure the file name shoud be citekey alone.
           "%(concat
  (when citar-org-roam-subdir (concat citar-org-roam-subdir \"/\")) \"${citekey}.org\")"
-          ":PROPERTIES:
-:ROAM_REFS: @${citekey}
-:END:
-#+title: ${title}\n")
+          "#+title: ${title}\n")
          :immediate-finish t
          :unnarrowed t))
       :info (list :citekey citekey)
       :node (org-roam-node-create :title title)
-      :props '(:finalize find-file))))
+      :props '(:finalize find-file))
+     (org-roam-ref-add (concat "@" citekey))))
 
 (defvar citar-org-roam--orig-source citar-notes-source)
 


### PR DESCRIPTION
Add citekey with `org-roam-ref-add'

Use `org-roam' builtin function `org-roam-ref-add' to add citekey for
better alignment of property values.

Close #8