### PR TITLE
Refactor completion candidates (again)

### DIFF
--- a/README.org
+++ b/README.org
@@ -43,7 +43,3 @@ To define a sub-file node as a bibliographic note (ref node), use =citar-org-roa
 Beyond that, the only interactive command this package provides is:
 
 - =citar-org-roam-cited=: presents a list of notes that cite the selected references
-
-** Limitations, caveats
-
-With the current candidate design, you must limit citekeys to 50 characters.

--- a/citar-org-roam.el
+++ b/citar-org-roam.el
@@ -47,8 +47,7 @@
         :items #'citar-org-roam--get-candidates
         :hasitems #'citar-org-roam-has-notes
         :open #'citar-org-roam-open-note
-        :create #'citar-org-roam--create-capture-note
-        :annotate #'citar-org-roam--annotate))
+        :create #'citar-org-roam--create-capture-note))
 
 (defvar citar-notes-source)
 (defvar citar-notes-sources)
@@ -97,7 +96,7 @@ note."
 (defun citar-org-roam-open-note (key-id)
   "Open or creat org-roam node for KEY-ID."
   (let ((id (substring-no-properties
-             (cadr (split-string key-id)))))
+             (car (split-string key-id)))))
     (citar-org-roam-open-note-from-id id)))
 
 (defun citar-org-roam-open-note-from-id (node-id)
@@ -159,11 +158,14 @@ space."
                                   (vconcat keys)))
         (cands (make-hash-table :test 'equal)))
     (prog1 cands
-      (pcase-dolist (`(,nodeid ,citekey ,_title) nodes)
+      (pcase-dolist (`(,nodeid ,citekey ,title) nodes)
         ;; TODO include note title in the candidate string?
         (push
-         (truncate-string-to-width
-          (concat citekey " " (propertize nodeid 'invisible t)) 87 nil 32)
+         (concat
+          (propertize nodeid 'invisible t) " ["
+          (propertize citekey 'face 'citar-highlight)
+          (truncate-string-to-width "] " (- 60 (length citekey)) nil 32)
+          (propertize title 'face 'citar))
          (gethash citekey cands))))))
 
 (defun citar-org-roam--create-capture-note (citekey entry)


### PR DESCRIPTION
- Reshuffle the list of substrings so the id we need is first.
- No longer use the annotation function, and place the title there.
- Only use truncate-string-to-width on the ending bracket (after the citekey).

This should ensure we avoid #16.

-----------------

![image](https://user-images.githubusercontent.com/1134/192574262-b5af0063-0f9f-47ce-a1c1-957388401fca.png)

```elisp
 (#("b2811bec-b2d4-4f58-8764-08dead0159a9 [cox2001]                                                    Three" 0 36
    (invisible t)
    38 45
    (face citar-highlight)
    98 103
    (face citar))))
```