### PR TITLE
Add citar-org-roam-capture-template-key

### DIFF
--- a/README.org
+++ b/README.org
@@ -40,6 +40,35 @@ To change the default new note output, you can modify the ~citar-org-roam-note-t
 (setq citar-org-roam-note-title-template "${author} - ${title}\n#+filetags: ${tags}")
 #+end_src
 
+Or to use the template already defined in your ~org-roam-capture-templates~, you can modify the
+~citar-org-roam-capture-template-key~ variable.
+
+As an example, ~org-roam-capture-templates~ is defined like so:
+
+#+begin_src emacs-lisp
+  (setq org-roam-capture-templates
+        '(("d" "default" plain
+           "%?"
+           :target
+           (file+head
+            "%<%Y%m%d%H%M%S>-${slug}.org"
+            "#+title: ${title}\n")
+           :unnarrowed t)
+          ("n" "literature note" plain
+           "%?"
+           :target
+           (file+head
+            "%(expand-file-name \"literature\" org-roam-directory)/${citekey}.org"
+            "#+TITLE: ${citekey}. ${title}.\n#+CREATED: %U\n#+LAST_MODIFIED: %U\n\n")
+           :unnarrowed t)))
+#+end_src
+
+if you want to use your "literature note" template you can set ~citar-org-roam-capture-template-key~ to its key, ="n"=.
+
+#+begin_src emacs-lisp
+  (setq citar-org-roam-capture-template-key "n")
+#+end_src
+
 ** Usage
 
 The =citar-open-notes= and =citar-open= commands will work as normal, but will use org-roam to open notes.

--- a/citar-org-roam.el
+++ b/citar-org-roam.el
@@ -40,6 +40,17 @@
   :group 'citar-org-roam
   :type 'string)
 
+(defcustom citar-org-roam-capture-template-key
+  nil
+  "When non-nil, `citar-org-roam--create-capture-note' will use the
+template associated with the key in `org-roam-capture-templates'.
+
+When nil (the default), the template will be creating a org file
+in `citar-org-roam-subdir' named after the citekey with
+`citar-org-roam-note-title-template' as the format of its title."
+  :group 'citar
+  :group 'citar-org-roam
+  :type 'string)
 ;; REVEIW experimental config
 (defconst citar-org-roam-notes-config
   (list :name "Org-Roam Notes"
@@ -169,23 +180,27 @@ space."
          (gethash citekey cands))))))
 
 (defun citar-org-roam--create-capture-note (citekey entry)
-    "Open or create org-roam node for CITEKEY and ENTRY."
-   ;; adapted from https://jethrokuan.github.io/org-roam-guide/#orgc48eb0d
-    (let ((title (citar-format--entry
-                   citar-org-roam-note-title-template entry)))
-     (org-roam-capture-
-      :templates
-      '(("r" "reference" plain "%?" :if-new
-         (file+head
-          "%(concat
- (when citar-org-roam-subdir (concat citar-org-roam-subdir \"/\")) \"${citekey}.org\")"
-          "#+title: ${title}\n")
-         :immediate-finish t
-         :unnarrowed t))
-      :info (list :citekey citekey)
-      :node (org-roam-node-create :title title)
-      :props '(:finalize find-file))
-     (org-roam-ref-add (concat "@" citekey))))
+  "Open or create org-roam node for CITEKEY and ENTRY."
+  ;; adapted from https://jethrokuan.github.io/org-roam-guide/#orgc48eb0d
+  (let ((title (citar-format--entry
+                citar-org-roam-note-title-template entry))
+        (key citar-org-roam-capture-template-key))
+    (apply 'org-roam-capture-
+           :info (list :citekey citekey)
+           :node (org-roam-node-create :title title)
+           :props '(:finalize find-file)
+           (if key
+               (list :keys key)
+             (list
+              :templates
+              '(("r" "reference" plain "%?" :if-new
+                 (file+head
+                  "%(concat
+     (when citar-org-roam-subdir (concat citar-org-roam-subdir \"/\")) \"${citekey}.org\")"
+                  "#+title: ${title}\n")
+                 :immediate-finish t
+                 :unnarrowed t)))))
+    (org-roam-ref-add (concat "@" citekey))))
 
 (defvar citar-org-roam--orig-source citar-notes-source)
 

--- a/citar-org-roam.el
+++ b/citar-org-roam.el
@@ -42,16 +42,18 @@
 
 (defcustom citar-org-roam-capture-template-key
   nil
-  "When non-nil, `citar-org-roam--create-capture-note' will use the
-template associated with the key in `org-roam-capture-templates'.
+  "When non-nil, use capture template associated with the key.
 
-When nil (the default), the template will be creating an org file
-in `citar-org-roam-subdir' named after the citekey with
+ `citar-org-roam--create-capture-note' will use the template
+associated with the key in `org-roam-capture-templates'.
+
+When nil (the default), the template will create an org file in
+`citar-org-roam-subdir' named after the citekey with
 `citar-org-roam-note-title-template' as the format of its title."
   :group 'citar
   :group 'citar-org-roam
   :type 'string)
-;; REVEIW experimental config
+
 (defconst citar-org-roam-notes-config
   (list :name "Org-Roam Notes"
         :category 'org-roam-node

--- a/citar-org-roam.el
+++ b/citar-org-roam.el
@@ -45,7 +45,7 @@
   "When non-nil, `citar-org-roam--create-capture-note' will use the
 template associated with the key in `org-roam-capture-templates'.
 
-When nil (the default), the template will be creating a org file
+When nil (the default), the template will be creating an org file
 in `citar-org-roam-subdir' named after the citekey with
 `citar-org-roam-note-title-template' as the format of its title."
   :group 'citar


### PR DESCRIPTION
I tweaked `citar-org-roam--create-capture-note` to work with my templates.

Here is the docstring of the variable:
```
When non-nil, `citar-org-roam--create-capture-note' will use the
template associated with the key in `org-roam-capture-templates'.

When nil (the default), the template will be creating a org file
in `citar-org-roam-subdir' named after the citekey with
`citar-org-roam-note-title-template' as the format of its title.
```