### PR TITLE
fix(setup): Require org-roam

### DIFF
--- a/README.org
+++ b/README.org
@@ -43,7 +43,3 @@ To define a sub-file node as a bibliographic note (ref node), use =citar-org-roa
 Beyond that, the only interactive command this package provides is:
 
 - =citar-org-roam-cited=: presents a list of notes that cite the selected references
-
-** Limitations, caveats
-
-With the current candidate design, you must limit citekeys to 50 characters.

--- a/README.org
+++ b/README.org
@@ -58,8 +58,8 @@ As an example, ~org-roam-capture-templates~ is defined like so:
            "%?"
            :target
            (file+head
-            "%(expand-file-name \"literature\" org-roam-directory)/${citekey}.org"
-            "#+TITLE: ${citekey}. ${title}.\n#+CREATED: %U\n#+LAST_MODIFIED: %U\n\n")
+            "%(expand-file-name (or citar-org-roam-subdir "") org-roam-directory)/${citekey}.org"
+            "#+title: ${citekey}. ${title}.\n#+created: %U\n#+last_modified: %U\n\n")
            :unnarrowed t)))
 #+end_src
 

--- a/README.org
+++ b/README.org
@@ -29,9 +29,9 @@ Activating ~citar-org-roam-mode~ will configure Citar to use these functions.
 
 #+begin_src emacs-lisp
 (use-package citar-org-roam
-  :after citar org-roam
-  :no-require
-  :config (citar-org-roam-mode))
+  :after (citar org-roam)
+  :config
+  (citar-org-roam-mode))
 #+end_src
 
 To change the default new note output, you can modify the ~citar-org-roam-note-title~ variable:

--- a/README.org
+++ b/README.org
@@ -1,3 +1,4 @@
+[[https://melpa.org/#/citar][file:https://melpa.org/packages/citar-org-roam-badge.svg]]
 
 * citar-org-roam
 
@@ -17,6 +18,10 @@ This package integrates directly with the Org-Roam database, and provides the fo
 
 #+CAPTION: citar-open command with citar-org-roam
 [[file:images/open-screenshot.png]]
+
+** Installation
+
+This package is available via [[https://melpa.org/#/citar-org-roam][MELPA]].
 
 ** Configuration
 

--- a/README.org
+++ b/README.org
@@ -11,7 +11,7 @@ This package integrates directly with the Org-Roam database, and provides the fo
  1. multiple references per note
  2. multiple reference notes per file
  3. ability to query note citations by reference
- 4. "live" updating of Citar UI note presence for references
+ 4. "live" updating of Citar UI for presence of notes
 
 ** Screenshot
 

--- a/README.org
+++ b/README.org
@@ -40,6 +40,35 @@ To change the default new note output, you can modify the ~citar-org-roam-note-t
 (setq citar-org-roam-note-title-template "${author} - ${title}\n#+filetags: ${tags}")
 #+end_src
 
+Or to use the template already defined in your ~org-roam-capture-templates~, you can modify the
+~citar-org-roam-capture-template-key~ variable.
+
+As an example, ~org-roam-capture-templates~ is defined like so:
+
+#+begin_src emacs-lisp
+  (setq org-roam-capture-templates
+        '(("d" "default" plain
+           "%?"
+           :target
+           (file+head
+            "%<%Y%m%d%H%M%S>-${slug}.org"
+            "#+title: ${title}\n")
+           :unnarrowed t)
+          ("n" "literature note" plain
+           "%?"
+           :target
+           (file+head
+            "%(expand-file-name \"literature\" org-roam-directory)/${citekey}.org"
+            "#+TITLE: ${citekey}. ${title}.\n#+CREATED: %U\n#+LAST_MODIFIED: %U\n\n")
+           :unnarrowed t)))
+#+end_src
+
+if you want to use your "literature note" template you can set ~citar-org-roam-capture-template-key~ to its key, ="n"=.
+
+#+begin_src emacs-lisp
+  (setq citar-org-roam-capture-template-key "n")
+#+end_src
+
 ** Usage
 
 The =citar-open-notes= and =citar-open= commands will work as normal, but will use org-roam to open notes.

--- a/README.org
+++ b/README.org
@@ -22,6 +22,13 @@ This package integrates directly with the Org-Roam database, and provides the fo
 
 Activating ~citar-org-roam-mode~ will configure Citar to use these functions.
 
+#+begin_src emacs-lisp
+(use-package citar-org-roam
+  :after citar org-roam
+  :no-require
+  :config (citar-org-roam-mode))
+#+end_src
+
 ** Usage
 
 The =citar-open-notes= and =citar-open= commands will work as normal, but will use org-roam to open notes.

--- a/README.org
+++ b/README.org
@@ -34,6 +34,12 @@ Activating ~citar-org-roam-mode~ will configure Citar to use these functions.
   :config (citar-org-roam-mode))
 #+end_src
 
+To change the default new note output, you can modify the ~citar-org-roam-note-title~ variable:
+
+#+begin_src emacs-lisp
+(setq citar-org-roam-note-title-template "${author} - ${title}\n#+filetags: ${tags}")
+#+end_src
+
 ** Usage
 
 The =citar-open-notes= and =citar-open= commands will work as normal, but will use org-roam to open notes.

--- a/README.org
+++ b/README.org
@@ -43,7 +43,7 @@ To change the default new note output, you can modify the ~citar-org-roam-note-t
 Or to use the template already defined in your ~org-roam-capture-templates~, you can modify the
 ~citar-org-roam-capture-template-key~ variable.
 
-As an example, ~org-roam-capture-templates~ is defined like so:
+As an example, ~org-roam-capture-templates~ is defined like so; where the ~title~ variable formatting will be determined by ~citar-org-roam-note-title-template~:
 
 #+begin_src emacs-lisp
   (setq org-roam-capture-templates

--- a/README.org
+++ b/README.org
@@ -43,3 +43,7 @@ To define a sub-file node as a bibliographic note (ref node), use =citar-org-roa
 Beyond that, the only interactive command this package provides is:
 
 - =citar-org-roam-cited=: presents a list of notes that cite the selected references
+
+** Limitations, caveats
+
+With the current candidate design, you must limit citekeys to 50 characters.

--- a/README.org
+++ b/README.org
@@ -11,6 +11,7 @@ This package integrates directly with the Org-Roam database, and provides the fo
  1. multiple references per note
  2. multiple reference notes per file
  3. ability to query note citations by reference
+ 4. "live" updating of Citar UI note presence for references
 
 ** Screenshot
 

--- a/README.org
+++ b/README.org
@@ -58,7 +58,7 @@ As an example, ~org-roam-capture-templates~ is defined like so:
            "%?"
            :target
            (file+head
-            "%(expand-file-name (or citar-org-roam-subdir "") org-roam-directory)/${citekey}.org"
+            "%(expand-file-name \"literature\" org-roam-directory)/${citekey}.org"
             "#+title: ${citekey}. ${title}.\n#+created: %U\n#+last_modified: %U\n\n")
            :unnarrowed t)))
 #+end_src

--- a/citar-org-roam.el
+++ b/citar-org-roam.el
@@ -167,11 +167,6 @@ space."
         ;; TODO include note title in the candidate string?
         (push (concat citekey " " (propertize nodeid 'invisible t)) (gethash citekey cands))))))
 
-(defun citar-org-roam-select-ref ()
-  "Return org-roam node-id for ref candidate."
-  ;; TODO just a demo ATM
-  (completing-read "ref:" (citar-org-roam--get-candidates)))
-
 (defun citar-org-roam--create-capture-note (citekey entry)
     "Open or create org-roam node for CITEKEY and ENTRY."
    ;; adapted from https://jethrokuan.github.io/org-roam-guide/#orgc48eb0d

--- a/citar-org-roam.el
+++ b/citar-org-roam.el
@@ -65,6 +65,8 @@
   "Return function to check for notes.
 When given a citekey, return non-nil if there's an associated
 note."
+  ;; Lookup performance for this function needs to be as fast as possible, so we
+  ;; use a hash-table.
   (let ((hasnotes (make-hash-table :test 'equal)))
     (dolist (citekey (citar-org-roam-keys-with-notes))
       (puthash citekey t hasnotes))

--- a/citar-org-roam.el
+++ b/citar-org-roam.el
@@ -154,7 +154,6 @@ This is just a wrapper for `org-roam-ref-add'."
 
 Each candidate is a citekey + node-id string, separated by a
 space."
-  ;; REVIEW experimental
   (let ((nodes (org-roam-db-query `[:select [refs:node-id refs:ref nodes:title]
                                             :from [refs nodes]
                                             :where (and (= refs:type "cite")
@@ -176,7 +175,6 @@ space."
       :templates
       '(("r" "reference" plain "%?" :if-new
          (file+head
-          ;; REVIEW not sure the file name shoud be citekey alone.
           "%(concat
  (when citar-org-roam-subdir (concat citar-org-roam-subdir \"/\")) \"${citekey}.org\")"
           "#+title: ${title}\n")

--- a/citar-org-roam.el
+++ b/citar-org-roam.el
@@ -163,7 +163,7 @@ space."
         ;; TODO include note title in the candidate string?
         (push
          (truncate-string-to-width
-          (concat citekey " " (propertize nodeid 'invisible t)) 60 nil 32)
+          (concat citekey " " (propertize nodeid 'invisible t)) 87 nil 32)
          (gethash citekey cands))))))
 
 (defun citar-org-roam--create-capture-note (citekey entry)

--- a/citar-org-roam.el
+++ b/citar-org-roam.el
@@ -107,7 +107,7 @@ note."
 (defun citar-org-roam-ref-add ()
   "Add a roam_ref to the node at point.
 
-This is just a wrapper for 'org-roam-ref-add'."
+This is just a wrapper for `org-roam-ref-add'."
   (interactive)
   (let ((ref (citar-select-ref)))
     (org-roam-ref-add (concat "@" ref))))
@@ -152,7 +152,7 @@ This is just a wrapper for 'org-roam-ref-add'."
 (defun citar-org-roam--get-candidates (&optional keys)
   "Return ref node candidate list, optionally filtered by KEYS.
 
-Each candidate is a 'citekey' + 'node-id' string, separated by a
+Each candidate is a citekey + node-id string, separated by a
 space."
   ;; REVIEW experimental
   (let ((nodes (org-roam-db-query `[:select [refs:node-id refs:ref nodes:title]
@@ -187,7 +187,7 @@ space."
           ":PROPERTIES:
 :ROAM_REFS: @${citekey}
 :END:
- #+title: ${title}\n")
+#+title: ${title}\n")
          :immediate-finish t
          :unnarrowed t))
       :info (list :citekey citekey)
@@ -197,13 +197,13 @@ space."
 (defvar citar-org-roam--orig-source citar-notes-source)
 
 (defun citar-org-roam-setup ()
-  "Setup 'citar-org-roam-mode'."
+  "Setup `citar-org-roam-mode'."
   (citar-register-notes-source
    'citar-org-roam citar-org-roam-notes-config)
   (setq citar-notes-source 'citar-org-roam))
 
 (defun citar-org-roam-reset ()
-  "Reset 'citar-org-roam-mode' to default."
+  "Reset `citar-org-roam-mode' to default."
   (setq citar-notes-source citar-org-roam--orig-source)
   (citar-remove-notes-source 'citar-org-roam))
 

--- a/citar-org-roam.el
+++ b/citar-org-roam.el
@@ -5,7 +5,7 @@
 ;; Author: Bruce D'Arcus <bdarcus@gmail.com>
 ;; Maintainer: Bruce D'Arcus <bdarcus@gmail.com>
 ;; Created: May 22, 2022
-;; Version: 0.1
+;; Version: 0.2
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;; SPDX-FileCopyrightText: 2022 Bruce D'Arcus
 ;; Homepage: https://github.com/emacs-citar/citar-org-roam

--- a/citar-org-roam.el
+++ b/citar-org-roam.el
@@ -5,7 +5,7 @@
 ;; Author: Bruce D'Arcus <bdarcus@gmail.com>
 ;; Maintainer: Bruce D'Arcus <bdarcus@gmail.com>
 ;; Created: May 22, 2022
-;; Version: 0.2
+;; Version: 0.3
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;; SPDX-FileCopyrightText: 2022 Bruce D'Arcus
 ;; Homepage: https://github.com/emacs-citar/citar-org-roam
@@ -202,7 +202,7 @@ space."
 
 ;;;###autoload
 (define-minor-mode citar-org-roam-mode
-  "Toggle citar-org-roam-mode."
+  "Toggle `citar-org-roam-mode'."
   :global t
   :group 'citar
   :lighter " citar-org-roam"

--- a/citar-org-roam.el
+++ b/citar-org-roam.el
@@ -85,13 +85,13 @@ note."
   (let* ((ids
          (org-roam-db-query [:select * :from citations
                              :where (= cite-key $s1)] reference))
-         ;; TODO candidates need to be more useful
-         (note
+         ;; TODO one issue on the citar side: the UI has no "has" indicators for
+         ;; these.
+         (node-id
           (if ids
               (completing-read "Note: " ids)
             (message "No notes cite this reference."))))
-    ;; TODO need to open the note.
-    note))
+    (org-roam-node-visit (org-roam-node-from-id node-id))))
 
 (defun citar-org-roam-open-note (key-id)
   "Open or creat org-roam node for KEY-ID."

--- a/citar-org-roam.el
+++ b/citar-org-roam.el
@@ -87,6 +87,7 @@ note."
                              :where (= cite-key $s1)] reference))
          ;; TODO one issue on the citar side: the UI has no "has" indicators for
          ;; these.
+         ;; Also need an annotation for this.
          (node-id
           (if ids
               (completing-read "Note: " ids)

--- a/citar-org-roam.el
+++ b/citar-org-roam.el
@@ -179,7 +179,8 @@ space."
       '(("r" "reference" plain "%?" :if-new
          (file+head
           ;; REVIEW not sure the file name shoud be citekey alone.
-          "%(concat citar-org-roam-subdir \"/\" \"${citekey}.org\")"
+          "%(concat
+ (when citar-org-roam-subdir (concat citar-org-roam-subdir \"/\")) \"${citekey}.org\")"
           ":PROPERTIES:
 :ROAM_REFS: @${citekey}
 :END:

--- a/citar-org-roam.el
+++ b/citar-org-roam.el
@@ -144,11 +144,7 @@ This is just a wrapper for `org-roam-ref-add'."
               (ref (org-roam-db-query
                     [:select ref :from refs
                      :where (= node-id $s1)] nodeid)))
-    (concat
-     "          " ; not thrilled with this
-     (truncate-string-to-width
-      (propertize citekey 'face 'citar-highlight) 15 nil 32)
-     (propertize (org-roam-node-title node) 'face 'citar))))
+    (propertize (org-roam-node-title node) 'face 'citar)))
 
 (defun citar-org-roam--get-candidates (&optional keys)
   "Return ref node candidate list, optionally filtered by KEYS.
@@ -165,7 +161,10 @@ space."
     (prog1 cands
       (pcase-dolist (`(,nodeid ,citekey ,_title) nodes)
         ;; TODO include note title in the candidate string?
-        (push (concat citekey " " (propertize nodeid 'invisible t)) (gethash citekey cands))))))
+        (push
+         (truncate-string-to-width
+          (concat citekey " " (propertize nodeid 'invisible t)) 60 nil 32)
+         (gethash citekey cands))))))
 
 (defun citar-org-roam--create-capture-note (citekey entry)
     "Open or create org-roam node for CITEKEY and ENTRY."

--- a/citar-org-roam.el
+++ b/citar-org-roam.el
@@ -47,8 +47,7 @@
         :items #'citar-org-roam--get-candidates
         :hasitems #'citar-org-roam-has-notes
         :open #'citar-org-roam-open-note
-        :create #'citar-org-roam--create-capture-note
-        :annotate #'citar-org-roam--annotate))
+        :create #'citar-org-roam--create-capture-note))
 
 (defvar citar-notes-source)
 (defvar citar-notes-sources)
@@ -97,7 +96,7 @@ note."
 (defun citar-org-roam-open-note (key-id)
   "Open or creat org-roam node for KEY-ID."
   (let ((id (substring-no-properties
-             (cadr (split-string key-id)))))
+             (car (split-string key-id)))))
     (citar-org-roam-open-note-from-id id)))
 
 (defun citar-org-roam-open-note-from-id (node-id)
@@ -159,11 +158,14 @@ space."
                                   (vconcat keys)))
         (cands (make-hash-table :test 'equal)))
     (prog1 cands
-      (pcase-dolist (`(,nodeid ,citekey ,_title) nodes)
+      (pcase-dolist (`(,nodeid ,citekey ,title) nodes)
         ;; TODO include note title in the candidate string?
         (push
-         (truncate-string-to-width
-          (concat citekey " " (propertize nodeid 'invisible t)) 87 nil 32)
+         (concat
+          (propertize nodeid 'invisible t) " ["
+          (propertize citekey 'face 'citar-highlight)
+          (truncate-string-to-width "] " (- 60 (length citekey)) nil 32)
+          (propertize title 'face 'citar))
          (gethash citekey cands))))))
 
 (defun citar-org-roam--create-capture-note (citekey entry)

--- a/citar-org-roam.el
+++ b/citar-org-roam.el
@@ -184,15 +184,13 @@ space."
           ;; REVIEW not sure the file name shoud be citekey alone.
           "%(concat
  (when citar-org-roam-subdir (concat citar-org-roam-subdir \"/\")) \"${citekey}.org\")"
-          ":PROPERTIES:
-:ROAM_REFS: @${citekey}
-:END:
-#+title: ${title}\n")
+          "#+title: ${title}\n")
          :immediate-finish t
          :unnarrowed t))
       :info (list :citekey citekey)
       :node (org-roam-node-create :title title)
-      :props '(:finalize find-file))))
+      :props '(:finalize find-file))
+     (org-roam-ref-add (concat "@" citekey))))
 
 (defvar citar-org-roam--orig-source citar-notes-source)
 

--- a/citar-org-roam.el
+++ b/citar-org-roam.el
@@ -93,7 +93,8 @@ note."
 
 (defun citar-org-roam-open-note (key-id)
   "Open or creat org-roam node for KEY-ID."
-  (let ((id (cadr (split-string key-id))))
+  (let ((id (substring-no-properties
+             (cadr (split-string key-id)))))
     (citar-org-roam-open-note-from-id id)))
 
 (defun citar-org-roam-open-note-from-id (node-id)


### PR DESCRIPTION
I'm not sure if this is the best approach, but it appears to fix #26.

Hmm ... now I'm unsure, complicated because I'm having problems with `org-roam` (really `emacsql-sqlite`).

I've also added a use-package change for the docs; will probably merge one or the other.