### PR TITLE
fix(setup): Run org-roam-db-sync

### DIFF
--- a/citar-org-roam.el
+++ b/citar-org-roam.el
@@ -208,6 +208,8 @@ space."
 
 (defun citar-org-roam-setup ()
   "Setup `citar-org-roam-mode'."
+  ;; This seems to require running if citar is loaded before org-roam.
+  (org-roam-db-sync)
   (citar-register-notes-source
    'citar-org-roam citar-org-roam-notes-config)
   (setq citar-notes-source 'citar-org-roam))


### PR DESCRIPTION
If citar is loaded before org-roam, the notes indicators will be empty.

This should fix that, by running `org-roam-db-sync` when setting `citar-org-roam-mode`.