### PR TITLE
fix: set default citar-org-roam-subdir nil

### DIFF
--- a/README.org
+++ b/README.org
@@ -59,7 +59,7 @@ As an example, with ~org-roam-capture-templates~ defined like so:
            "%?"
            :target
            (file+head
-            "%(expand-file-name \"literature\" org-roam-directory)/${citar-citekey}.org"
+            "%(expand-file-name citar-org-roam-subdir org-roam-directory)/${citar-citekey}.org"
             "#+title: ${citar-citekey} (${citar-date}). ${note-title}.\n#+created: %U\n#+last_modified: %U\n\n")
            :unnarrowed t)))
 #+end_src

--- a/citar-org-roam.el
+++ b/citar-org-roam.el
@@ -27,7 +27,7 @@
 (require 'org-roam)
 (require 'citar)
 
-(defcustom citar-org-roam-subdir "references"
+(defcustom citar-org-roam-subdir nil
   "Org-roam subdirectory to place reference notes."
   :group 'citar
   :group 'citar-org-roam


### PR DESCRIPTION
Set this default value to `nil`, update template example in docs.

Close: #36