### PR TITLE
Add function to open Citar UI for current node

### DIFF
--- a/README.org
+++ b/README.org
@@ -83,4 +83,4 @@ To define a sub-file node as a bibliographic note (ref node), use =citar-org-roa
 Beyond that, the only interactive command this package provides is:
 
 - =citar-org-roam-cited=: presents a list of notes that cite the selected references
-- =citar-org-roam-open-node-at-point=: Opens Citar UI for all cite references associated with the roam-node in the current buffer.
+- =citar-org-roam-open-current-refs=: Opens Citar UI for all cite references associated with the roam-node in the current buffer.

--- a/README.org
+++ b/README.org
@@ -83,3 +83,4 @@ To define a sub-file node as a bibliographic note (ref node), use =citar-org-roa
 Beyond that, the only interactive command this package provides is:
 
 - =citar-org-roam-cited=: presents a list of notes that cite the selected references
+- =citar-org-roam-open-node-at-point=: Opens Citar UI for all cite references associated with the roam-node in the current buffer.

--- a/citar-org-roam.el
+++ b/citar-org-roam.el
@@ -124,16 +124,25 @@ note."
             (message "No notes cite this reference."))))
     (org-roam-node-visit (org-roam-node-from-id node-id))))
 
-(defun citar-org-roam-open-node-at-point ()
-  "Calls `citar-open' on all citar cite-keys in the :ROAM_REFS:
-property of the current org-roam node."
-  (interactive)
-  (let ((citar-open-prompt t)
-	(refs (seq-filter (lambda (key) (gethash key (citar-get-entries)))
-			  (org-roam-node-refs (org-roam-node-at-point)))))
-    (if refs
-	(citar-open refs)
-      (message "No CiteRefs for this note"))))
+(defun citar-org-roam--node-cite-refs (roam-node)
+  "Returns citation keys in :ROAM_REFS: property of ROAM-NODE"
+  (seq-filter (lambda (key) (gethash key (citar-get-entries)))
+	      (org-roam-node-refs roam-node)))
+
+(defun citar-org-roam-open-current-refs (&optional prefix)
+  "With the point in the body of an org-roam node, this function
+calls `citar-open' on all citar cite keys in the :ROAM_REFS:
+property of the node.
+
+If PREFIX is given prompts to select one or more of the cite keys
+before calling `citar-open' on them."
+  (interactive "P")
+  (if-let ((citar-open-prompt t)
+	   (refs (citar-org-roam--node-cite-refs (org-roam-node-at-point))))
+      (if prefix
+	  (citar-open (citar-select-refs :filter (lambda (key) (member key refs))))
+	(citar-open refs))
+    (message "No CiteRefs for this note")))
 
 (defun citar-org-roam-open-note (key-id)
   "Open or creat org-roam node for KEY-ID."

--- a/citar-org-roam.el
+++ b/citar-org-roam.el
@@ -124,6 +124,17 @@ note."
             (message "No notes cite this reference."))))
     (org-roam-node-visit (org-roam-node-from-id node-id))))
 
+(defun citar-org-roam-open-node-at-point ()
+  "Calls `citar-open' on all citar cite-keys in the :ROAM_REFS:
+property of the current org-roam node."
+  (interactive)
+  (let ((citar-open-prompt t)
+	(refs (seq-filter (lambda (key) (gethash key (citar-get-entries)))
+			  (org-roam-node-refs (org-roam-node-at-point)))))
+    (if refs
+	(citar-open refs)
+      (message "No CiteRefs for this note"))))
+
 (defun citar-org-roam-open-note (key-id)
   "Open or creat org-roam node for KEY-ID."
   (let ((id (substring-no-properties


### PR DESCRIPTION
`citar-org-roam-open-node-at-point` opens Citar UI for all cite references associated with the roam-node in the current buffer. This is especially useful for finding and opening other attachments to said references..