### PR TITLE
customisation option for note display string in Citar UI

### DIFF
--- a/README.org
+++ b/README.org
@@ -74,6 +74,11 @@ In that example template, the ~note-title~ template variable includes the format
 Note also the template includes some ~citar~-related template variables, including ~citar-date~.
 This is an example of data passed from ~citar~ to the capture template, the details of which you can configure in ~citar-org-roam-template-fields~.
 
+*** Note Completion Candidates
+
+The display string for org-roam notes attached to a reference in the Citar UI
+can be customised by setting ~org-roam-cite-format-note-candidate-fn~.
+
 ** Usage
 
 The =citar-open-notes= and =citar-open= commands will work as normal, but will use org-roam to open notes.

--- a/citar-org-roam.el
+++ b/citar-org-roam.el
@@ -78,7 +78,7 @@ candidates in the Citar UI.
 
 The function should accept three arguments `nodeid', `citekey'
 and `title' and return a formatted string. For an example see
-`citar-org-roam-format-candidate'"
+`citar-org-roam-format-note-candidate'"
   :group 'citar
   :group 'citar-org-roam
   :type 'function)


### PR DESCRIPTION
Introduces a new variable `citar-org-roam-format-candidate-fn` which defines the function used to format the display string for roam notes in the Citar UI. This allows users to easily define a new format for these.

Also changes the default format to include the note title. With possibly multiple notes attached to the same CiteRef the citekey is not necessarily a unique identifier.


I'm not entirely sure this is the best solution to allowing customisation. I played around with using org-roams own templating system but that would've been a much more involved change. I think the solution in this PR is flexible enough. 

The API for the formatting function is easily expandable by exposing more node properties. This might be wise to do to discourage users from doing their own additional queries to the roam database in the formatting function.


Love the package btw. thanks for creating it! :)