### PR TITLE
Fix MELPA link

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,4 +1,4 @@
-[[https://melpa.org/#/citar][file:https://melpa.org/packages/citar-org-roam-badge.svg]]
+[[https://melpa.org/#/citar-org-roam][file:https://melpa.org/packages/citar-org-roam-badge.svg]]
 
 * citar-org-roam
 


### PR DESCRIPTION
Previously, MELPA badge/shield for `citar-org-roam` was displayed, but it linked to `citar`, but now we link to `citar-org-roam` on melpa