### PR TITLE
Rename `:if-new` to `:target` in capture template

### DIFF
--- a/citar-org-roam.el
+++ b/citar-org-roam.el
@@ -9,7 +9,7 @@
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;; SPDX-FileCopyrightText: 2022 Bruce D'Arcus
 ;; Homepage: https://github.com/emacs-citar/citar-org-roam
-;; Package-Requires: ((emacs "27.1") (org-roam "2.2") (citar "1.2.0"))
+;; Package-Requires: ((emacs "27.1") (org-roam "2.2.0") (citar "1.2.0"))
 ;;
 ;; This file is not part of GNU Emacs.
 ;;

--- a/citar-org-roam.el
+++ b/citar-org-roam.el
@@ -250,7 +250,7 @@ space."
                (list :keys templatekey)
                (list
                 :templates
-                '(("r" "reference" plain "%?" :if-new
+                '(("r" "reference" plain "%?" :target
                    (file+head
                     "%(concat
      (when citar-org-roam-subdir (concat citar-org-roam-subdir \"/\")) \"${citar-citekey}.org\")"


### PR DESCRIPTION
Org-roam renamed the property `:if-new` to `:target` for org-roam-capture-templates in version [2.2.0](https://github.com/org-roam/org-roam/blob/main/CHANGELOG.md#220-2022-01-14).

Closes: #59 
